### PR TITLE
fix: it didn't work correctly when the import path contains "."

### DIFF
--- a/called_test.go
+++ b/called_test.go
@@ -9,6 +9,6 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	defer called.ExportSetFlagFuncs("b.Func,(*b.Type).Method, b/bsub.Type.Method")()
+	defer called.ExportSetFlagFuncs("b.Func,(*b.Type).Method, (b/bsub.Type).Method,github.com/gostaticanalysis/c.Func,(*github.com/gostaticanalysis/c.Type).Method,(github.com/gostaticanalysis/c/csub.Type).Method")()
 	analysistest.Run(t, testdata, called.Analyzer, "a")
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -3,6 +3,9 @@ package a
 import (
 	"b"
 	"b/bsub"
+
+	"github.com/gostaticanalysis/c"
+	"github.com/gostaticanalysis/c/csub"
 )
 
 func afunc() {
@@ -52,6 +55,27 @@ func main() {
 	(bsub.Type).Method(bsub.Type{}) // OK
 	//lint:ignore called OK
 	m4(bsub.Type{}) // OK
+
+	c.Func()    // want `github\.com/gostaticanalysis/c\.Func must not be called`
+	_ = c.Func  // OK
+	g := c.Func // OK
+	g()         // want `github\.com/gostaticanalysis/c\.Func must not be called`
+
+	new(c.Type).Method()          // want `\(\*github\.com/gostaticanalysis/c\.Type\)\.Method must not be called`
+	_ = new(c.Type).Method        // OK
+	m5 := new(c.Type).Method      // OK
+	m5()                          // want `\(\*github\.com/gostaticanalysis/c\.Type\)\.Method must not be called`
+	(*c.Type).Method(new(c.Type)) // want `\(\*github\.com/gostaticanalysis/c\.Type\)\.Method must not be called`
+	m6 := (*c.Type).Method        // OK
+	m6(new(c.Type))               // want `\(\*github\.com/gostaticanalysis/c\.Type\)\.Method must not be called`
+
+	csub.Type{}.Method()            // want `\(github\.com/gostaticanalysis/c/csub\.Type\)\.Method must not be called`
+	_ = csub.Type{}.Method          // OK
+	m7 := csub.Type{}.Method        // OK
+	m7()                            // want `\(github\.com/gostaticanalysis/c/csub\.Type\)\.Method must not be called`
+	(csub.Type).Method(csub.Type{}) // want `\(github\.com/gostaticanalysis/c/csub\.Type\)\.Method must not be called`
+	m8 := (csub.Type).Method        // OK
+	m8(csub.Type{})                 // want `\(github\.com/gostaticanalysis/c/csub\.Type\)\.Method must not be called`
 
 	afunc() // OK
 }

--- a/testdata/src/github.com/gostaticanalysis/c/c.go
+++ b/testdata/src/github.com/gostaticanalysis/c/c.go
@@ -1,0 +1,7 @@
+package c
+
+func Func() {}
+
+type Type struct{}
+
+func (*Type) Method() {}

--- a/testdata/src/github.com/gostaticanalysis/c/csub/csub.go
+++ b/testdata/src/github.com/gostaticanalysis/c/csub/csub.go
@@ -1,0 +1,5 @@
+package csub
+
+type Type struct{}
+
+func (Type) Method() {}


### PR DESCRIPTION
This PR fixes that `called` doesn't work correctly when an import path contains `.`. 

An import path contains `.` when the target function is imported from an external package. So, the format for `-called.funcs` should be like `github.com/gostaticanalysis/pkg.Func` in this case. However, the following line splits a passed function name by `.` to get the package name, type name and function/method name:
https://github.com/gostaticanalysis/called/blob/1d8d4f8b1086ccc541038b7203e218d0b9ed7147/called.go#L60

For example, `github.com/gostaticanalysis/pkg.Func` is split into `["github", "com/gostaticanalysis/pkg", "Func"]` .

## ⚠️ BREAKING CHANGE

- `()` is required when specifying methods in `-called.funcs`
    - This is the same behavior as `-printf.funcs` for `printf` analyzer