### PR TITLE
Add TagPR workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,20 @@
+name: tagpr
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  tagpr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ func main() {
 	log.Fatal("hoge")
 }
 ```
+## Release
+
+This repository uses [tagpr] to automatically create release pull requests when changes are merged to the main branch.
+
 
 <!-- links -->
 [gopkg]: https://pkg.go.dev/github.com/gostaticanalysis/called
 [gopkg-badge]: https://pkg.go.dev/badge/github.com/gostaticanalysis/called?status.svg
+[tagpr]: https://github.com/Songmu/tagpr


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run Songmu/tagpr when PRs are merged to main
- document TagPR usage in README